### PR TITLE
Add OPAM control files for easier installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,20 +160,13 @@ $ opam pin add edn https://github.com/prepor/ocaml-edn.git
 Package edn does not exist, create as a NEW package ? [Y/n] y
 edn is now git-pinned to https://github.com/prepor/ocaml-edn.git
 [… Installation output excluded …]
+$ opam pin add eq https://github.com/jonase/eq.git
+Package eq does not exist, create as a NEW package ? [Y/n] y
+eq is now git-pinned to https://github.com/jonase/eq.git
+[… Installation output excluded …]
 ```
 
-* Clone the [eq](https://github.com/jonase/eq) repo and build the
-  binary
-
-```
-$ git clone https://github.com/jonase/eq
-$ cd eq
-$ ocamlbuild -use-ocamlfind src/eq.native
-$ mv eq.native eq
-```
-
-and move `eq` to somewhere on your `$PATH`
-
+`eq` is now in the `bin` directory of OPAM.
 
 ## License
 

--- a/eq.install
+++ b/eq.install
@@ -1,0 +1,3 @@
+bin: [
+  "_build/src/eq.native" {"eq"}
+]

--- a/opam
+++ b/opam
@@ -1,0 +1,18 @@
+opam-version: "1.2"
+name: "eq"
+version: "0.1"
+maintainer: "Jonas Enlund <jonas.enlund@gmail.com>"
+author: "Jonas Enlund <jonas.enlund@gmail.com>"
+homepage: "https://github.com/jonase/eq"
+license: "MIT"
+bug-reports: "https://github.com/jonase/eq/issues"
+dev-repo: "https://github.com/jonase/eq.git"
+depends: [
+  "ocamlfind" {build}
+  "ocamlbuild" {build}
+  "easy-format"
+  "edn"
+]
+build: [
+  ["ocamlbuild" "-use-ocamlfind" "src/eq.native"]
+]


### PR DESCRIPTION
Especially when edn will hit OPAM, this will reduce from two commands to just one command, no cloning required, just works.
